### PR TITLE
Fix black/shell detection with never versions of imagemagick; add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:16.04
+RUN apt-get update
+RUN apt-get -y upgrade
+RUN apt-get -y install parallel bc rdesktop imagemagick xdotool xvfb
+ADD stickyKeysSlayer.sh /
+ADD docker_wrapper.sh /
+ENTRYPOINT ["./docker_wrapper.sh"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ DEFCON24 Presentation Slides: [http://www.slideshare.net/DennisMaldonado5/sticky
 
 Video demo of stickyKeysSlayer can be found here: [https://www.youtube.com/watch?v=Jy4hg4a1FYI](https://www.youtube.com/watch?v=Jy4hg4a1FYI)
 
+
 Dependencies:
 ----------------
 * imagemagick
@@ -27,7 +28,39 @@ All packages exist in the Kali repositories:
     apt-get update
     
     apt-get -y install imagemagick xdotool parallel bc
-	
+
+Docker:
+-------
+
+In some situations, running this tool within Docker may be advantageous.  To do so, first build it:
+
+```
+docker build -t sticky-keys-slayer .
+```
+
+Then run the container, passing in necessary arguments to `stickyKeysSlayer.sh`:
+
+```
+docker run --rm -it --name sticky-keys-slayer --net=host sticky-keys-slayer -o /tmp/pics <target>
+```
+
+If you'd like to save the screenshots of vulnerable systems:
+
+```
+mkdir pics
+docker run --rm -it --name sticky-keys-slayer --net=host -v `pwd`/pics:/tmp/foo/ sticky-keys-slayer -o /tmp/pics <target>
+```
+
+If you'd like to pass in a list of hosts to run and save the screenshots
+
+```
+mkdir pics
+# put some hosts in hosts.txt
+echo 192.168.0.1 > hosts.txt
+docker run --rm -it --name sticky-keys-slayer --net=host -v `pwd`/hosts.txt:/tmp/hosts.txt -v `pwd`/pics:/tmp/foo/ sticky-keys-slayer -o /tmp/pics /tmp/hosts.txt
+```
+
+
 	
 To Do:
 ----------------

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ DEFCON24 Presentation Slides: [http://www.slideshare.net/DennisMaldonado5/sticky
 
 Video demo of stickyKeysSlayer can be found here: [https://www.youtube.com/watch?v=Jy4hg4a1FYI](https://www.youtube.com/watch?v=Jy4hg4a1FYI)
 
-
 Dependencies:
 ----------------
 * imagemagick
@@ -26,7 +25,7 @@ Dependencies:
 All packages exist in the Kali repositories:
 
     apt-get update
-    
+
     apt-get -y install imagemagick xdotool parallel bc
 
 Docker:
@@ -60,8 +59,6 @@ echo 192.168.0.1 > hosts.txt
 docker run --rm -it --name sticky-keys-slayer --net=host -v `pwd`/hosts.txt:/tmp/hosts.txt -v `pwd`/pics:/tmp/foo/ sticky-keys-slayer -o /tmp/pics /tmp/hosts.txt
 ```
 
-
-	
 To Do:
 ----------------
 * Detection of missed boxes (boxes to which we do not obtain a screenshot)

--- a/docker_wrapper.sh
+++ b/docker_wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+Xvfb :0 -ac -screen 0 1280x720x16 -nolisten tcp &
+./stickyKeysSlayer.sh $@

--- a/stickyKeysSlayer.sh
+++ b/stickyKeysSlayer.sh
@@ -172,7 +172,7 @@ function screenshot {
 function testBlack {
 	local IMAGE=$1
 	local RETVAR=$2
-	local BLACK=$(convert $IMAGE -format %c histogram:info:- | grep "\#000000 " | cut -d : -f 1 | tr -d ' ')
+	local BLACK=$(convert $IMAGE -format %c histogram:info:- | grep "\#000000* " | cut -d : -f 1 | tr -d ' ')
 	if [ -z "$BLACK" ]
 	then
 		local BLACK=0


### PR DESCRIPTION
I saw the video for this today, was intrigued and decided to give it a shot.  

I had some difficulties getting this to work on updated versions of Ubuntu, in particular as it relates to detection of the black terminals -- that was a simple fix to look for additional zeros:

```
2017-08-10 22:26:21 10.4.17.9 [v] Screenshot saved to /tmp/foo/10.4.17.9.png for Window ID: 2097154
    189471: (    0,    0,    0) #000000000000 black   
````

While here I also got this working in a docker container, which someone may find helpful in the future.  In my case, I didn't have the necessary tooling to even attempt to get any of this running on OS X so I took the docker route rather than kali/virtualbox/etc.

Thanks for this tool, @linuz.  Very helpful!